### PR TITLE
Log errors in async reporter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,22 +4,47 @@ PATH
     pliny-librato (0.1.0)
       concurrent-ruby (~> 1.0)
       librato-metrics (~> 2.0)
+      pliny (>= 0.20.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.2.7.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     aggregate (0.2.2)
     byebug (9.0.6)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
+    erubis (2.7.0)
     faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
+    http_accept (0.1.6)
+    i18n (0.7.0)
+    json (1.8.3)
+    json_schema (0.15.0)
     librato-metrics (2.0.2)
       aggregate (~> 0.2.2)
       faraday
     method_source (0.8.2)
+    minitest (5.10.1)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
+    pliny (0.20.0)
+      activesupport (~> 4.1, >= 4.1.0)
+      http_accept (~> 0.1, >= 0.1.5)
+      multi_json (~> 1.9, >= 1.9.3)
+      prmd (~> 0.11, >= 0.11.4)
+      sinatra (~> 1.4, >= 1.4.7)
+      sinatra-router (~> 0.2, >= 0.2.3)
+      thor (~> 0.19, >= 0.19.1)
+    prmd (0.12.0)
+      erubis (~> 2.7)
+      json_schema (~> 0.3, >= 0.3.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -27,6 +52,9 @@ GEM
     pry-byebug (3.4.1)
       byebug (~> 9.0)
       pry (~> 0.10)
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -41,8 +69,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-router (0.2.3)
+      sinatra (~> 1.4)
     slop (3.6.0)
+    thor (0.19.4)
+    thread_safe (0.3.5)
+    tilt (2.0.5)
     timecop (0.8.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -50,8 +89,8 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.13)
   pliny-librato!
-  pry
-  pry-byebug
+  pry (~> 0.10)
+  pry-byebug (~> 3.4)
   rake (~> 10.0)
   rspec (~> 3.3)
   timecop (~> 0.8.1)

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -1,5 +1,6 @@
 require "librato/metrics"
 require "concurrent"
+require "pliny/error_reporters"
 
 module Pliny::Librato
   module Metrics
@@ -21,10 +22,14 @@ module Pliny::Librato
 
       def _report_counts(counts)
         ::Librato::Metrics.submit(expand(:counter, counts))
+      rescue => error
+        Pliny::ErrorReporters.notify(error)
       end
 
       def _report_measures(measures)
         ::Librato::Metrics.submit(expand(:gauge, measures))
+      rescue => error
+        Pliny::ErrorReporters.notify(error)
       end
 
       private

--- a/pliny-librato.gemspec
+++ b/pliny-librato.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "librato-metrics", "~> 2.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "librato-metrics", "~> 2.0"
+  spec.add_dependency "pliny",           ">= 0.20.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "pry", "~> 0.10"

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
 
       backend.await._report_counts('pliny.foo' => 1, 'pliny.bar' => 2)
     end
+
+    it "reports errors via the error reporter" do
+      error = StandardError.new(message: "Something went wrong")
+      allow(Librato::Metrics).to receive(:submit).and_raise(error)
+      expect(Pliny::ErrorReporters).to receive(:notify).with(error)
+
+      backend.await._report_counts("pliny.boom" => 1)
+    end
   end
 
   describe "#report_measures" do
@@ -45,6 +53,14 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
       )
 
       backend.report_measures('pliny.foo' => 1.002)
+    end
+
+    it "reports errors via the error reporter" do
+      error = StandardError.new(message: "Something went wrong")
+      allow(Librato::Metrics).to receive(:submit).and_raise(error)
+      expect(Pliny::ErrorReporters).to receive(:notify).with(error)
+
+      backend.await._report_measures("pliny.boom" => 1)
     end
   end
 


### PR DESCRIPTION
- Pins the minimum required version of pliny.
- Adds error handling to the librato API calls, otherwise they will quietly fail in a separate thread and we'd never see them.