### PR TITLE
Use gauges everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,16 @@
-**0.2.0**
+Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- All metrics sent to librato will be reported as gauges. This means that
+  `Pliny::Metrics.count` will be a gauge, to provide compatiblity with l2met
+  "count#" entries, which are also submitted as gauges.
+
+## 0.2.0
 - Catch and report errors in async calls to the Librato API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pliny-librato (0.1.0)
+    pliny-librato (0.2.0)
       concurrent-ruby (~> 1.0)
       librato-metrics (~> 2.0)
       pliny (>= 0.20.0)
@@ -34,7 +34,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    pliny (0.20.0)
+    pliny (0.20.1)
       activesupport (~> 4.1, >= 4.1.0)
       http_accept (~> 0.1, >= 0.1.5)
       multi_json (~> 1.9, >= 1.9.3)

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -13,21 +13,15 @@ module Pliny::Librato
       end
 
       def report_counts(counts)
-        self.async._report_counts(counts)
+        self.async.report(counts)
       end
 
       def report_measures(measures)
-        self.async._report_measures(measures)
+        self.async.report(measures)
       end
 
-      def _report_counts(counts)
-        ::Librato::Metrics.submit(expand(:counter, counts))
-      rescue => error
-        Pliny::ErrorReporters.notify(error)
-      end
-
-      def _report_measures(measures)
-        ::Librato::Metrics.submit(expand(:gauge, measures))
+      def report(metrics)
+        ::Librato::Metrics.submit(serialize(metrics))
       rescue => error
         Pliny::ErrorReporters.notify(error)
       end
@@ -36,9 +30,9 @@ module Pliny::Librato
 
       attr_reader :librato_client, :source
 
-      def expand(type, metrics)
+      def serialize(metrics)
         metrics.reduce({}) do |mets, (k, v)|
-          mets[k] = { type: type, value: v, source: source }
+          mets[k] = { type: :gauge, value: v, source: source }
           mets
         end
       end

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -1,14 +1,15 @@
 require "spec_helper"
 
 RSpec.describe Pliny::Librato::Metrics::Backend do
-  subject(:source)  { "myapp.production" }
-  subject(:backend) { described_class.new(source: source) }
+  subject(:source)     { "myapp.production" }
+  subject(:backend)    { described_class.new(source: source) }
+  let(:async_reporter) { double("AsyncReporter", report: true) }
+
 
   describe "#report_counts" do
-    let(:async_reporter) { double(_report_counts: true) }
-    it "delegates to async._report_counts" do
+    it "delegates to async.report" do
       expect(backend).to receive(:async).and_return(async_reporter)
-      expect(async_reporter).to receive(:_report_counts).once.with(
+      expect(async_reporter).to receive(:report).once.with(
         'pliny.foo' => 1
       )
 
@@ -16,70 +17,42 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     end
   end
 
-  describe "#async._report_counts" do
-    it "reports a single count to librato" do
-      expect(Librato::Metrics).to receive(:submit).with(
-        'pliny.foo' => { value: 1, type: :counter, source: source }
-      )
-
-      backend.await._report_counts('pliny.foo' => 1)
-    end
-
-    it "reports multiple counts to librato" do
-      expect(Librato::Metrics).to receive(:submit).with(
-        'pliny.foo' => { value: 1, type: :counter, source: source },
-        'pliny.bar' => { value: 2, type: :counter, source: source }
-      )
-
-      backend.await._report_counts('pliny.foo' => 1, 'pliny.bar' => 2)
-    end
-
-    it "reports errors via the error reporter" do
-      error = StandardError.new(message: "Something went wrong")
-      allow(Librato::Metrics).to receive(:submit).and_raise(error)
-      expect(Pliny::ErrorReporters).to receive(:notify).with(error)
-
-      backend.await._report_counts("pliny.boom" => 1)
-    end
-  end
-
   describe "#report_measures" do
-    let(:async_reporter) { double(_report_measures: true) }
-
-    it "delegates to async._report_measures" do
+    it "delegates to async._report" do
       expect(backend).to receive(:async).and_return(async_reporter)
-      expect(async_reporter).to receive(:_report_measures).once.with(
+      expect(async_reporter).to receive(:report).once.with(
         'pliny.foo' => 1.002
       )
 
       backend.report_measures('pliny.foo' => 1.002)
     end
 
+  end
+
+  describe "#report" do
+    it "reports a single count to librato" do
+      expect(Librato::Metrics).to receive(:submit).with(
+        'pliny.foo' => { value: 1, type: :gauge, source: source }
+      )
+
+      backend.report('pliny.foo' => 1)
+    end
+
+    it "reports multiple counts to librato" do
+      expect(Librato::Metrics).to receive(:submit).with(
+        'pliny.foo' => { value: 1, type: :gauge, source: source },
+        'pliny.bar' => { value: 2, type: :gauge, source: source }
+      )
+
+      backend.report('pliny.foo' => 1, 'pliny.bar' => 2)
+    end
+
     it "reports errors via the error reporter" do
       error = StandardError.new(message: "Something went wrong")
       allow(Librato::Metrics).to receive(:submit).and_raise(error)
       expect(Pliny::ErrorReporters).to receive(:notify).with(error)
 
-      backend.await._report_measures("pliny.boom" => 1)
-    end
-  end
-
-  describe "#async._report_measures" do
-    it "reports a single measure to librato" do
-      expect(Librato::Metrics).to receive(:submit).with(
-        'pliny.foo' => { value: 1.002, type: :gauge, source: source }
-      )
-
-      backend.await._report_measures('pliny.foo' => 1.002)
-    end
-
-    it "reports multiple measures to librato" do
-      expect(Librato::Metrics).to receive(:submit).with(
-        'pliny.foo' => { value: 1.5, type: :gauge, source: source },
-        'pliny.bar' => { value: 2.04, type: :gauge, source: source }
-      )
-
-      backend.await._report_measures('pliny.foo' => 1.5, 'pliny.bar' => 2.04)
+      backend.report("pliny.boom" => 1)
     end
   end
 end

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
   end
 
   describe "#report_measures" do
-    it "delegates to async._report" do
+    it "delegates to async.report" do
       expect(backend).to receive(:async).and_return(async_reporter)
       expect(async_reporter).to receive(:report).once.with(
         'pliny.foo' => 1.002


### PR DESCRIPTION
Librato's l2met functionality means that anything logged as "count#foo=1" will be reported as a `gauge` in Librato's system. 

Using a `counter` type here means backwards incompatibility with anyone previously Pliny::Metrics.count("foo", 1), because `foo` would have been registered as a gauge.

This PR uses gauges for all metric reporting.