### PR TITLE
Queue metrics for batch reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- The backend now queues metrics and sends in batches
+- You can specify the `count` and `interval` for batch sends when initializing
+  the backend.
+
+### Removed
+
+- `concurrent-ruby` is no longer a dependency.
+
 ## 0.3.0
 
 ### Changed
@@ -15,4 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   "count#" entries, which are also submitted as gauges.
 
 ## 0.2.0
+
+### Changed
+
 - Catch and report errors in async calls to the Librato API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pliny-librato (0.2.0)
+    pliny-librato (0.3.0)
       concurrent-ruby (~> 1.0)
       librato-metrics (~> 2.0)
       pliny (>= 0.20.0)
@@ -26,7 +26,7 @@ GEM
     http_accept (0.1.6)
     i18n (0.7.0)
     json (1.8.3)
-    json_schema (0.15.0)
+    json_schema (0.16.0)
     librato-metrics (2.0.2)
       aggregate (~> 0.2.2)
       faraday
@@ -34,7 +34,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    pliny (0.20.1)
+    pliny (0.21.0)
       activesupport (~> 4.1, >= 4.1.0)
       http_accept (~> 0.1, >= 0.1.5)
       multi_json (~> 1.9, >= 1.9.3)
@@ -42,7 +42,7 @@ GEM
       sinatra (~> 1.4, >= 1.4.7)
       sinatra-router (~> 0.2, >= 0.2.3)
       thor (~> 0.19, >= 0.19.1)
-    prmd (0.12.0)
+    prmd (0.13.0)
       erubis (~> 2.7)
       json_schema (~> 0.3, >= 0.3.1)
     pry (0.10.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     pliny-librato (0.3.0)
-      concurrent-ruby (~> 1.0)
       librato-metrics (~> 2.0)
       pliny (>= 0.20.0)
 
@@ -18,7 +17,6 @@ GEM
     aggregate (0.2.2)
     byebug (9.0.6)
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     faraday (0.10.0)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Librato::Metrics.authenticate(Config.librato_email, Config.librato_key)
 Pliny::Metrics.backends << Pliny::Librato::Metrics::Backend.new(source: "myapp.production")
 ```
 
-Now `Pliny::Metrics` methods send directly to Librato:
+Now `Pliny::Metrics` methods will build a queue and automatically send metrics
+to Librato.
 
 ```ruby
 Pliny::Metrics.count(:foo, 3)
@@ -35,6 +36,9 @@ Pliny::Metrics.measure(:bar) do
   # Some stuff you want to time
 end
 ```
+
+By default, it will send queued metrics every minute, or whenever the
+queue reaches 1000 metrics. These settings can be configured on initialization.
 
 ## Development
 
@@ -44,4 +48,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/pliny-librato.
+Bug reports and pull requests are welcome on GitHub at https://github.com/heroku/pliny-librato.

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -10,7 +10,7 @@ module Pliny
         attr_reader :queue
 
         def initialize(source: nil, interval: 60, count: 1000, queue: nil)
-          @queue = queue || Librato::Metrics::Queue.new(
+          @queue = queue || ::Librato::Metrics::Queue.new(
             source:              source,
             autosubmit_interval: interval,
             autosubmit_count:    count

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -1,40 +1,38 @@
-require "librato/metrics"
-require "concurrent"
-require "pliny/error_reporters"
+require 'librato/metrics'
+require 'pliny/error_reporters'
 
 module Pliny::Librato
   module Metrics
     class Backend
-      include Concurrent::Async
+      attr_reader :queue
 
-      def initialize(source: nil)
-        super()
-        @source = source
+      def initialize(source: nil, interval: 60, count: 1000, queue: nil)
+        @queue = queue || Librato::Metrics::Queue.new(
+          source:              source,
+          autosubmit_interval: interval,
+          autosubmit_count:    count
+        )
+        flush_on_shutdown
       end
 
       def report_counts(counts)
-        self.async.report(counts)
+        report(counts)
       end
 
       def report_measures(measures)
-        self.async.report(measures)
-      end
-
-      def report(metrics)
-        ::Librato::Metrics.submit(serialize(metrics))
-      rescue => error
-        Pliny::ErrorReporters.notify(error)
+        report(measures)
       end
 
       private
 
-      attr_reader :librato_client, :source
+      def report(metrics)
+        queue.add(metrics)
+      rescue => error
+        Pliny::ErrorReporters.notify(error)
+      end
 
-      def serialize(metrics)
-        metrics.reduce({}) do |mets, (k, v)|
-          mets[k] = { type: :gauge, value: v, source: source }
-          mets
-        end
+      def flush_on_shutdown
+        Signal.trap('TERM') { queue.submit }
       end
     end
   end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -1,38 +1,42 @@
 require 'librato/metrics'
 require 'pliny/error_reporters'
 
-module Pliny::Librato
-  module Metrics
-    class Backend
-      attr_reader :queue
+module Pliny
+  module Librato
+    module Metrics
+      # Implements the Pliny::Metrics.backends API. Puts any metrics sent
+      # from Pliny::Metrics onto a queue that gets submitted in batches.
+      class Backend
+        attr_reader :queue
 
-      def initialize(source: nil, interval: 60, count: 1000, queue: nil)
-        @queue = queue || Librato::Metrics::Queue.new(
-          source:              source,
-          autosubmit_interval: interval,
-          autosubmit_count:    count
-        )
-        flush_on_shutdown
-      end
+        def initialize(source: nil, interval: 60, count: 1000, queue: nil)
+          @queue = queue || Librato::Metrics::Queue.new(
+            source:              source,
+            autosubmit_interval: interval,
+            autosubmit_count:    count
+          )
+          flush_on_shutdown
+        end
 
-      def report_counts(counts)
-        report(counts)
-      end
+        def report_counts(counts)
+          report(counts)
+        end
 
-      def report_measures(measures)
-        report(measures)
-      end
+        def report_measures(measures)
+          report(measures)
+        end
 
-      private
+        private
 
-      def report(metrics)
-        queue.add(metrics)
-      rescue => error
-        Pliny::ErrorReporters.notify(error)
-      end
+        def report(metrics)
+          queue.add(metrics)
+        rescue => error
+          Pliny::ErrorReporters.notify(error)
+        end
 
-      def flush_on_shutdown
-        Signal.trap('TERM') { queue.submit }
+        def flush_on_shutdown
+          Signal.trap('TERM') { queue.submit }
+        end
       end
     end
   end

--- a/pliny-librato.gemspec
+++ b/pliny-librato.gemspec
@@ -4,29 +4,29 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pliny/librato/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "pliny-librato"
+  spec.name          = 'pliny-librato'
   spec.version       = Pliny::Librato::VERSION
-  spec.authors       = ["Andrew Appleton", "Josh W Lewis"]
-  spec.email         = "andysapple@gmail.com"
+  spec.authors       = ['Andrew Appleton', 'Josh W Lewis']
+  spec.email         = 'andysapple@gmail.com'
 
-  spec.summary       = %q{A Librato metrics reporter backend for pliny}
-  spec.homepage      = "https://github.com/appleton/pliny-librato"
+  spec.summary       = 'A Librato metrics reporter backend for pliny'
+  spec.homepage      = 'https://github.com/appleton/pliny-librato'
 
-  spec.licenses      = ["MIT"]
+  spec.licenses      = ['MIT']
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "librato-metrics", "~> 2.0"
-  spec.add_dependency "pliny",           ">= 0.20.0"
+  spec.add_dependency 'librato-metrics', '~> 2.0'
+  spec.add_dependency 'pliny',           '>= 0.20.0'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "pry", "~> 0.10"
-  spec.add_development_dependency "pry-byebug", "~> 3.4"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "timecop", "~> 0.8.1"
+  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'pry-byebug', '~> 3.4'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.3'
+  spec.add_development_dependency 'timecop', '~> 0.8.1'
 end

--- a/pliny-librato.gemspec
+++ b/pliny-librato.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "librato-metrics", "~> 2.0"
   spec.add_dependency "pliny",           ">= 0.20.0"
 


### PR DESCRIPTION
The current incarnation of this backend can be heavy on IO, memory, and cost if you are submitting a large volume of metrics.

This PR changes the backend to use `librato-metrics`'s queue to batch and send Metrics. This should allow reporting to be less memory, IO, and cost intensive. 

It also removes the threading logic completely along with the `concurrent-ruby` dependency.

One caveat here:

The autosubmit features are only triggered on `add` calls. This means that if we haven't reported in 60 seconds, we'll report on the next `add` call. That means there could be a lag between the time 60 seconds expires and the time metrics are reported. The same issue also applies to the queue depth. These issues would be more prominent for apps that do less frequent reporting.