### PR TITLE
Threaded reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Metrics are now reported to Librato from within a thread to prevent blocking
+
+### Changed
+
+- The backend must be started with `#start`. For example
+  `Backend.new(opts).start`.
+
 ## 0.4.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pliny-librato (0.3.0)
+    pliny-librato (0.4.0)
       librato-metrics (~> 2.0)
       pliny (>= 0.20.0)
 
@@ -24,7 +24,7 @@ GEM
     http_accept (0.1.6)
     i18n (0.7.0)
     json (1.8.3)
-    json_schema (0.16.0)
+    json_schema (0.16.1)
     librato-metrics (2.0.2)
       aggregate (~> 0.2.2)
       faraday

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ end
 By default, it will send queued metrics every minute, or whenever the
 queue reaches 1000 metrics. These settings can be configured on initialization.
 
+## Shutdown
+By default, any unsubmitted metrics on the queue will not be sent at shutdown. It is the responsibility of the caller to trigger this.
+
+```ruby
+# In the main process
+Signal.trap('TERM') do
+  librato_backend.stop
+end
+
+# e.g. in Puma
+on_worker_shutdown do
+  librato_backend.stop
+end
+
+# e.g. in Sidekiq
+Sidekiq.configure_server do |config|
+  config.on(:shutdown) do
+    librato_backend.stop
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [Librato](https://librato.com) metrics reporter backend for [pliny](https://github.com/interagent/pliny).
 
+
+This backend will push reported metrics onto a queue, then periodically
+submit them asynchronously.
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -24,7 +28,9 @@ Add a new initializer `config/initializers/librato.rb`:
 
 ```ruby
 Librato::Metrics.authenticate(Config.librato_email, Config.librato_key)
-Pliny::Metrics.backends << Pliny::Librato::Metrics::Backend.new(source: "myapp.production")
+librato_backend = Pliny::Librato::Metrics::Backend.new(source: "myapp.production")
+librato_backend.start
+Pliny::Metrics.backends << librato_backend
 ```
 
 Now `Pliny::Metrics` methods will build a queue and automatically send metrics

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -25,7 +25,6 @@ module Pliny
 
         def start
           start_thread
-          Signal.trap('TERM') { stop }
           self
         end
 

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -41,18 +41,18 @@ module Pliny
         def start_thread
           @thread = Thread.new 'pliny-librato-metrics-processor' do
             loop do
-              message = queue.pop
-              break unless process(message)
+              msg = metrics_queue.pop
+              break unless process(msg)
             end
           end
         end
 
-        def process(message)
-          if message == POISON_PILL
+        def process(msg)
+          if msg == POISON_PILL
             flush_librato
             false
           else
-            enqueue_librato(message)
+            enqueue_librato(msg)
             true
           end
         end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -51,7 +51,6 @@ module Pliny
           end
         end
 
-
         def process(msg)
           if msg == POISON_PILL
             flush_librato
@@ -63,13 +62,15 @@ module Pliny
         end
 
         def enqueue_librato(msg)
-          librato_queue.add(msg)
-        rescue => error
-          Pliny::ErrorReporters.notify(error)
+          with_error_report { librato_queue.add(msg) }
         end
 
         def flush_librato
-          librato_queue.submit
+          with_error_report { librato_queue.submit }
+        end
+
+        def with_error_report
+          yield
         rescue => error
           Pliny::ErrorReporters.notify(error)
         end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -10,7 +10,7 @@ module Pliny
         POISON_PILL = :'❨╯°□°❩╯︵┻━┻'.freeze
 
         def initialize(source: nil, interval: 10, count: 500, **opts)
-          @metrics_queue = opts.fetch(:message_queue, Queue.new)
+          @metrics_queue = opts.fetch(:metrics_queue, Queue.new)
           @librato_queue = opts.fetch(:librato_queue,
                                       ::Librato::Metrics::Queue.new(
                                         source:              source,

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     )
   end
 
-  after { backend.shutdown }
-
   describe '#initialize' do
     subject(:backend) do
       described_class.new(
@@ -53,6 +51,11 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     before do
       allow(librato_queue).to receive(:submit)
       allow(librato_queue).to receive(:add)
+      backend.start
+    end
+
+    after do
+      backend.stop
     end
 
     it 'adds the metrics the librato_queue' do
@@ -71,11 +74,13 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     it_should_behave_like 'a metrics reporter'
   end
 
-  describe '#shutdown' do
+  describe '#stop' do
     it 'flushes the librato queue' do
+      backend.start
+
       expect(librato_queue).to receive(:submit)
 
-      backend.shutdown
+      backend.stop
     end
   end
 end

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -4,46 +4,34 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
   let(:source)        { 'myapp.production' }
   let(:interval)      { 1 }
   let(:count)         { 5 }
-  let(:librato_queue) { double('librato-queue') }
+  let(:librato_queue) { instance_double(Librato::Metrics::Queue) }
   let(:metrics)       { { 'foo.bar' => 1, baz: 2 } }
 
   subject(:backend) do
     described_class.new(
-      count:         count,
-      interval:      interval,
-      source:        source,
-      librato_queue: librato_queue
+      count:    count,
+      interval: interval,
+      source:   source
     )
   end
 
+
   describe '#initialize' do
-    subject(:backend) do
-      described_class.new(
-        count:         count,
-        interval:      interval,
-        source:        source
-      )
+    it 'creates a Librato::Metrics::Queue' do
+      expect(Librato::Metrics::Queue).to receive(:new).with(
+        autosubmit_count:    count,
+        autosubmit_interval: interval,
+        source:              source
+      ).and_call_original
+
+      expect(backend.send(:librato_queue))
+        .to be_an_instance_of(Librato::Metrics::Queue)
     end
 
-    context 'without a provided librato_queue' do
-      it 'creates a Librato::Metrics::Queue' do
-        expect(Librato::Metrics::Queue).to receive(:new).with(
-          autosubmit_count:    count,
-          autosubmit_interval: interval,
-          source:              source
-        ).and_call_original
+    it 'creates a new Queue' do
+      expect(Queue).to receive(:new).and_call_original
 
-        expect(backend.send(:librato_queue))
-          .to be_an_instance_of(Librato::Metrics::Queue)
-      end
-    end
-
-    context 'without a provided metrics_queue' do
-      it 'creates a new Queue' do
-        expect(Queue).to receive(:new).and_call_original
-
-        expect(backend.send(:metrics_queue)).to be_an_instance_of(Queue)
-      end
+      expect(backend.send(:metrics_queue)).to be_an_instance_of(Queue)
     end
   end
 
@@ -51,6 +39,7 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     before do
       allow(librato_queue).to receive(:submit)
       allow(librato_queue).to receive(:add)
+      allow(backend).to receive(:librato_queue).and_return(librato_queue)
       backend.start
     end
 
@@ -74,12 +63,26 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     it_should_behave_like 'a metrics reporter'
   end
 
-  describe '#stop' do
-    it 'flushes the librato queue' do
+  describe '#start' do
+    after do
+      backend.stop
+    end
+
+    it 'creates a new thread' do
+      expect(Thread).to receive(:new).and_call_original
       backend.start
+      expect(backend.send(:thread)).to be_a(Thread)
+    end
+  end
 
+  describe '#stop' do
+    before do
+      allow(backend).to receive(:librato_queue).and_return(librato_queue)
+      backend.start
+    end
+
+    it 'flushes the librato queue' do
       expect(librato_queue).to receive(:submit)
-
       backend.stop
     end
   end


### PR DESCRIPTION
This changes the reporter to queue and send to librato asynchronously and in it's own thread. The previous implementation would report a batch of metrics in-band, and potentially block other operations.

For instance, if an API was serving a request and it happened to trigger the 500th metric, the API wouldn't respond until we submitted those 500 metrics to Librato.

With this change, sending metrics to Librato should never block http responses, sidekiq jobs, etc.