### PR TITLE
Reliable flush interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- The default submission interval is now 60 seconds for consistency with
+  l2met and this project's README.
+- Metrics are now regularly submitted on the desired interval. Previously,
+  a new metric would need to be queued after the interval expired.
+
 ## 0.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ Pliny::Metrics.measure(:bar) do
 end
 ```
 
-By default, it will send queued metrics every minute, or whenever the
-queue reaches 1000 metrics. These settings can be configured on initialization.
+By default, it will send queued metrics every minute, and anytime the
+queue reaches 500 metrics. These settings can be configured on initialization.
 
 ## Shutdown
-By default, any unsubmitted metrics on the queue will not be sent at shutdown. It is the responsibility of the caller to trigger this.
+By default, any unsubmitted metrics on the queue will not be sent at shutdown. 
+It is the responsibility of the caller to trigger this.
 
 ```ruby
 # In the main process

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -9,7 +9,7 @@ module Pliny
       class Backend
         POISON_PILL = :'❨╯°□°❩╯︵┻━┻'
 
-        def initialize(source: nil, interval: 10, count: 500)
+        def initialize(source: nil, interval: 60, count: 500)
           @source   = source
           @interval = interval
           @count    = count

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -41,7 +41,7 @@ module Pliny
         attr_reader :source, :interval, :count, :timer, :counter
 
         def start_timer
-          @timer = Thread.new('pliny-librato-timer') do
+          @timer = Thread.new do
             loop do
               sleep interval
               flush_librato
@@ -50,7 +50,7 @@ module Pliny
         end
 
         def start_counter
-          @counter = Thread.new('pliny-librato-counter') do
+          @counter = Thread.new do
             loop do
               msg = metrics_queue.pop
               msg == POISON_PILL ? break : enqueue_librato(msg)

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -15,13 +15,11 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
     )
   end
 
-
   describe '#initialize' do
     it 'creates a Librato::Metrics::Queue' do
       expect(Librato::Metrics::Queue).to receive(:new).with(
-        autosubmit_count:    count,
-        autosubmit_interval: interval,
-        source:              source
+        autosubmit_count: count,
+        source:           source
       ).and_call_original
 
       expect(backend.send(:librato_queue))
@@ -64,14 +62,23 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
   end
 
   describe '#start' do
+    before do
+      allow(Thread).to receive(:new).and_call_original
+    end
+
     after do
       backend.stop
     end
 
-    it 'creates a new thread' do
+    it 'creates a new counter thread' do
+      backend.start
+      expect(backend.send(:counter)).to be_a(Thread)
+    end
+
+    it 'creates a new timer thread' do
       expect(Thread).to receive(:new).and_call_original
       backend.start
-      expect(backend.send(:thread)).to be_a(Thread)
+      expect(backend.send(:timer)).to be_a(Thread)
     end
   end
 


### PR DESCRIPTION
The `autosubmit_interval` for `Librato::Metrics::Queue` doesn't submit on the interval exactly, instead, it submits all metrics only after both the interval expired **AND** another metric is submitted. That means that if no metrics are added for a long period of time, the previous metrics will remain queued for that time. If any queued metrics are timestamped too long ago, Librato's API will reject the queue submission. Additional detail is outlined on #8.

This PR aims to fix that, so that even if no further metrics are queued, we still flush the queue at the target interval. We're doing this by starting another thread, that periodically submits the queued metrics.

Since we're using two threads to access the `Librato::Queue` (which is not threadsafe), I've implemented a `Mutex` to control access.