### PR TITLE
Potential deadlock in #stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Removed potential deadlock when stopping the backend.
+
+### Changed
+
+- `Backend#stop` can no longer be called from within a `Signal.trap` block.
+
 ## 0.5.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ queue reaches 500 metrics. These settings can be configured on initialization.
 By default, any unsubmitted metrics on the queue will not be sent at shutdown.
 It is the responsibility of the caller to trigger this.
 
+**Note**: `#stop` will not work with signal traps, as mutexes can't be obtained within traps.
+
 ```ruby
 # In the main process
 Kernel.at_exit do

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ By default, it will send queued metrics every minute, and anytime the
 queue reaches 500 metrics. These settings can be configured on initialization.
 
 ## Shutdown
-By default, any unsubmitted metrics on the queue will not be sent at shutdown. 
+By default, any unsubmitted metrics on the queue will not be sent at shutdown.
 It is the responsibility of the caller to trigger this.
 
 ```ruby
 # In the main process
-Kernel.on_exit do
+Kernel.at_exit do
   librato_backend.stop
 end
 

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -32,7 +32,8 @@ module Pliny
 
         def stop
           metrics_queue.push(POISON_PILL)
-          timer.terminate
+          # Ensure timer is not running when we terminate it
+          sync { timer.terminate }
           counter.join
           flush_librato
         end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -13,6 +13,7 @@ module Pliny
           @source   = source
           @interval = interval
           @count    = count
+          @mutex    = Mutex.new
         end
 
         def report_counts(counts)
@@ -67,13 +68,9 @@ module Pliny
         end
 
         def sync(&block)
-          mutex.synchronize(&block)
+          @mutex.synchronize(&block)
         rescue => error
           Pliny::ErrorReporters.notify(error)
-        end
-
-        def mutex
-          @mutex ||= Mutex.new
         end
 
         def metrics_queue


### PR DESCRIPTION
While reviewing #9 I noticed a potential deadlock during the execution of `#stop`. This change addresses that by synchronizing around the `timer.terminate` call.

This change also moves the instantiation of `@mutex` to the initiliazer, as I'm assuming that `@mutex ||= Mutex.new` isn't thread safe by default. Same applies to `metrics_queue` and `librato_queue`.

**Note**: This change will not work with invoking `librato_backend.stop` from within a `Signal#trap` but that's noted in the README.md.