### PR TITLE
Utilize Aggregator and CounterCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 
 ## Usage
 
-Add a new initializer `config/initializers/librato.rb`:
+Update (or add) your metrics initializer `config/initializers/metrics.rb` with:
 
 ```ruby
 if Config.librato_email && Config.librato_key

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Pliny::Metrics.measure(:bar) do
 end
 ```
 
-By default, it will send queued metrics every minute, and anytime the
-queue reaches 500 metrics. These settings can be configured on initialization.
+By default, it will send queued metrics every minute, but can be configured on initialization.
 
 ## Shutdown
 By default, any unsubmitted metrics on the queue will not be sent at shutdown.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,15 @@ Or install it yourself as:
 Add a new initializer `config/initializers/librato.rb`:
 
 ```ruby
-Librato::Metrics.authenticate(Config.librato_email, Config.librato_key)
-librato_backend = Pliny::Librato::Metrics::Backend.new(source: "myapp.production")
-librato_backend.start
-Pliny::Metrics.backends << librato_backend
+if Config.librato_email && Config.librato_key
+  Librato::Metrics.authenticate(Config.librato_email, Config.librato_key)
+  Pliny::Metrics.backends = [Pliny::Librato::Metrics::Backend.new(
+    source: "#{Config.app_name}.#{Config.app_env}",
+    interval: 30
+  ).tap(&:start)]
+else
+  Pliny::Metrics.backends = [Pliny::Metrics::Backends::Logger]
+end
 ```
 
 Now `Pliny::Metrics` methods will build a queue and automatically send metrics

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -56,8 +56,11 @@ module Pliny
 
         def flush_librato
           sync do
+            $stderr.puts "pliny-librato: counter_cache.flush_to: %s" % counter_cache.instance_variable_get(:@cache).inspect
             counter_cache.flush_to(librato_queue)
+            $stderr.puts "pliny-librato: aggregator being merged: %s" % aggregator.queued.inspect
             librato_queue.merge!(aggregator)
+            $stderr.puts "pliny-librato: librato queue being submitted: %s" % librato_queue.queued.inspect
             librato_queue.submit
             aggregator.clear
           end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -44,7 +44,7 @@ module Pliny
 
         private
 
-        attr_reader :interval, :timer, :counter, :counter_cache, :aggregator, :librato_queue
+        attr_reader :interval, :timer, :counter_cache, :aggregator, :librato_queue
 
         def start_timer
           @timer = Thread.new do

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -63,6 +63,7 @@ module Pliny
             librato_queue.merge!(aggregator)
             aggregator.clear
           end
+          librato_queue.submit
         end
 
         def sync(&block)

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -26,7 +26,9 @@ module Pliny
         end
 
         def report_measures(measures)
-          aggregator.add(measures)
+          sync do
+            aggregator.add(measures)
+          end
         end
 
         def start

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -61,7 +61,6 @@ module Pliny
           sync do
             counter_cache.flush_to(librato_queue)
             librato_queue.merge!(aggregator)
-            librato_queue.submit
             aggregator.clear
           end
         end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -56,16 +56,11 @@ module Pliny
 
         def flush_librato
           sync do
-            $stderr.puts "pliny-librato: counter_cache.flush_to: %s" % counter_cache.instance_variable_get(:@cache).inspect
             counter_cache.flush_to(librato_queue)
-            $stderr.puts "pliny-librato: aggregator being merged: %s" % aggregator.queued.inspect
             librato_queue.merge!(aggregator)
-            unless librato_queue.empty?
-              $stderr.puts "pliny-librato: librato queue being submitted: %s" % librato_queue.queued.inspect
-              librato_queue.submit
-            end
             aggregator.clear
           end
+          librato_queue.submit
         end
 
         def sync(&block)

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -60,8 +60,10 @@ module Pliny
             counter_cache.flush_to(librato_queue)
             $stderr.puts "pliny-librato: aggregator being merged: %s" % aggregator.queued.inspect
             librato_queue.merge!(aggregator)
-            $stderr.puts "pliny-librato: librato queue being submitted: %s" % librato_queue.queued.inspect
-            librato_queue.submit
+            unless librato_queue.empty?
+              $stderr.puts "pliny-librato: librato queue being submitted: %s" % librato_queue.queued.inspect
+              librato_queue.submit
+            end
             aggregator.clear
           end
         end

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -20,8 +20,10 @@ module Pliny
         end
 
         def report_counts(counts)
-          counts.each do |name, val|
-            counter_cache.increment(name, val)
+          sync do
+            counts.each do |name, val|
+              counter_cache.increment(name, val)
+            end
           end
         end
 

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -13,7 +13,10 @@ module Pliny
           @mutex         = Mutex.new
           @counter_cache = ::Librato::Collector::CounterCache.new(default_tags: nil)
           @aggregator    = ::Librato::Metrics::Aggregator.new
-          @librato_queue = ::Librato::Metrics::Queue.new(source: source)
+          @librato_queue = ::Librato::Metrics::Queue.new(
+            source: source,
+            skip_measurement_times: true
+          )
         end
 
         def report_counts(counts)

--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -1,5 +1,6 @@
 require 'librato/metrics'
 require 'pliny/error_reporters'
+require 'librato/collector'
 
 module Pliny
   module Librato
@@ -7,12 +8,11 @@ module Pliny
       # Implements the Pliny::Metrics.backends API. Puts any metrics sent
       # from Pliny::Metrics onto a queue that gets submitted in batches.
       class Backend
-        POISON_PILL = :'❨╯°□°❩╯︵┻━┻'
-
         def initialize(source: nil, interval: 60, count: 500)
           @interval      = interval
           @mutex         = Mutex.new
-          @metrics_queue = Queue.new
+          @counter_cache = ::Librato::Collector::CounterCache.new(default_tags: nil)
+          @aggregator    = ::Librato::Metrics::Aggregator.new
           @librato_queue = ::Librato::Metrics::Queue.new(
             source:           source,
             autosubmit_count: count
@@ -20,30 +20,29 @@ module Pliny
         end
 
         def report_counts(counts)
-          metrics_queue.push(counts)
+          counts.each do |name, val|
+            counter_cache.increment(name, val)
+          end
         end
 
         def report_measures(measures)
-          metrics_queue.push(measures)
+          aggregator.add(measures)
         end
 
         def start
-          start_counter
           start_timer
           self
         end
 
         def stop
-          metrics_queue.push(POISON_PILL)
           # Ensure timer is not running when we terminate it
           sync { timer.terminate }
-          counter.join
           flush_librato
         end
 
         private
 
-        attr_reader :interval, :timer, :counter, :metrics_queue, :librato_queue
+        attr_reader :interval, :timer, :counter, :counter_cache, :aggregator, :librato_queue
 
         def start_timer
           @timer = Thread.new do
@@ -54,21 +53,13 @@ module Pliny
           end
         end
 
-        def start_counter
-          @counter = Thread.new do
-            loop do
-              msg = metrics_queue.pop
-              msg == POISON_PILL ? break : enqueue_librato(msg)
-            end
-          end
-        end
-
-        def enqueue_librato(msg)
-          sync { librato_queue.add(msg) }
-        end
-
         def flush_librato
-          sync { librato_queue.submit }
+          sync do
+            counter_cache.flush_to(librato_queue)
+            librato_queue.merge!(aggregator)
+            librato_queue.submit
+            aggregator.clear
+          end
         end
 
         def sync(&block)

--- a/pliny-librato.gemspec
+++ b/pliny-librato.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'librato-metrics', '~> 2.0'
   spec.add_dependency 'pliny',           '>= 0.20.0'
+  spec.add_dependency 'librato-rack',    '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'pry', '~> 0.10'

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 RSpec.describe Pliny::Librato::Metrics::Backend do
   let(:source)        { 'myapp.production' }
   let(:interval)      { 1 }
-  let(:count)         { 5 }
-  let(:librato_queue) { instance_double(Librato::Metrics::Queue) }
+  let(:librato_queue) { Librato::Metrics::Queue.new(skip_measurement_times: true) }
+  let(:counter_cache) { Librato::Collector::CounterCache.new(default_tags: nil) }
+  let(:aggregator)    { Librato::Metrics::Aggregator.new }
   let(:metrics)       { { 'foo.bar' => 1, baz: 2 } }
 
   subject(:backend) do
     described_class.new(
-      count:    count,
       interval: interval,
       source:   source
     )
@@ -18,25 +18,41 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
   describe '#initialize' do
     it 'creates a Librato::Metrics::Queue' do
       expect(Librato::Metrics::Queue).to receive(:new).with(
-        autosubmit_count: count,
-        source:           source
+        source: source,
+        skip_measurement_times: true,
       ).and_call_original
 
       expect(backend.send(:librato_queue))
         .to be_an_instance_of(Librato::Metrics::Queue)
     end
 
-    it 'creates a new Queue' do
-      expect(Queue).to receive(:new).and_call_original
+    it 'creates a Librato::Metrics::Aggregator' do
+      expect(Librato::Metrics::Aggregator).to receive(:new).and_call_original
 
-      expect(backend.send(:metrics_queue)).to be_an_instance_of(Queue)
+      expect(backend.send(:librato_queue))
+        .to be_an_instance_of(Librato::Metrics::Queue)
+    end
+
+  end
+
+  describe '#report_counts' do
+    it 'utilizes the counter cache' do
+      allow(backend).to receive(:counter_cache).and_return(counter_cache)
+      10.times do
+        backend.report_counts(metrics)
+      end
+
+      expected = {
+        "foo.bar"=>{:name=>"foo.bar", :value=>10},
+        "baz"=>{:name=>"baz", :value=>20}
+      }
+      expect(counter_cache.instance_variable_get(:@cache)).to eq(expected)
     end
   end
 
-  shared_examples 'a metrics reporter' do
+  describe '#report_measures' do
     before do
-      allow(librato_queue).to receive(:submit)
-      allow(librato_queue).to receive(:add)
+      allow(librato_queue).to receive(:merge!)
       allow(backend).to receive(:librato_queue).and_return(librato_queue)
       backend.start
     end
@@ -45,34 +61,52 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
       backend.stop
     end
 
-    it 'adds the metrics the librato_queue' do
-      expect(librato_queue).to receive(:add).with(metrics)
-      backend.send(method, metrics)
+    it 'utilizes the aggregator' do
+      allow(backend).to receive(:aggregator).and_return(aggregator)
+      10.times do
+        backend.report_measures(metrics)
+      end
+      expected = {
+        :gauges=>[
+          {:name=>"foo.bar", :count=>10, :sum=>10.0, :min=>1.0, :max=>1.0},
+          {:name=>"baz", :count=>10, :sum=>20.0, :min=>2.0, :max=>2.0}
+        ]
+      }
+      expect(aggregator.queued).to eq(expected)
     end
   end
 
-  describe '#report_counts' do
-    let(:method) { :report_counts }
-    it_should_behave_like 'a metrics reporter'
-  end
+  describe '#flush_librato' do
+    it 'grabs the counter and aggregator' do
+      allow(backend).to receive(:librato_queue).and_return(librato_queue)
+      allow(librato_queue).to receive(:submit)
 
-  describe '#report_measures' do
-    let(:method) { :report_measures }
-    it_should_behave_like 'a metrics reporter'
+      backend.report_counts(requests: { value: 1 })
+      backend.report_measures(request_time: { value: 10 })
+      backend.send(:flush_librato)
+
+      expected = {
+        :gauges=>[
+          {:name=>"requests", :value=>1},
+          {:name=>"request_time", :count=>1, :sum=>10.0, :min=>10.0, :max=>10.0}
+        ]
+      }
+
+      expect(librato_queue.queued).to eq(expected)
+    end
   end
 
   describe '#start' do
     before do
+      allow(backend).to receive(:librato_queue).and_return(librato_queue)
+      allow(librato_queue).to receive(:submit)
+
       allow(Thread).to receive(:new).and_call_original
       backend.start
     end
 
     after do
       backend.stop
-    end
-
-    it 'creates a new counter thread' do
-      expect(backend.send(:counter)).to be_a(Thread)
     end
 
     it 'creates a new timer thread' do

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -77,12 +77,12 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
   end
 
   describe '#flush_librato' do
-    it 'grabs the counter and aggregator' do
+    it 'merges the counter_cache and aggregator' do
       allow(backend).to receive(:librato_queue).and_return(librato_queue)
       allow(librato_queue).to receive(:submit)
 
-      backend.report_counts(requests: { value: 1 })
-      backend.report_measures(request_time: { value: 10 })
+      backend.report_counts(requests: 1)
+      backend.report_measures(request_time: 10)
       backend.send(:flush_librato)
 
       expected = {


### PR DESCRIPTION
Closes #11 

I'm running an experiment now, and it seems this change doesn't
actually change the metric names visibly, and the change is more
behind the scenes.

## Counters

This is a relatively obvious change, and there's little to no
downside just doing this.

```ruby
10.times do |i|
  Pliny::Metrics.count "foo", i
end
```

Results in a single submission within a tick of:

```
{name: "foo", value: 45}
```

## Measurements

```ruby
10.times do |i|
  Pliny::Metrics.measure "foo" do
    sleep i
  end
end
```

That would submit a single measurement as follows:

```
{name: "foo", count: 10, sum: 45, min: 0, max: 9}
```

And that would all be accessible from your metric page by
choosing the appropriate summary function.

Contentious points:

- Should we just copy `CounterCache` from librato-rack, or do
  we add it as a dependency. I do not have a strong opinion
  on this one, having done more go recently, the "copy what
  you only need" approach is more frequently favored.
- Should we try to still use Queue as before? I'm leaning heavily
  to just stop doing it, as we are just unnecessarily bumping
  our rate limit use without much benefit (e.g. we'd still be using
  SSA regardless, the net numbers would be the same, etc)