### PR TITLE
Fix the synchronization problems with the queue

### DIFF
--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
 
       backend.new_librato_queue
     end
+
+    it 'is configured to not autosubmit_check' do
+      autosubmit_check = !!backend.new_librato_queue.send(:autosubmit_check)
+      expect(autosubmit_check).to eq(false)
+    end
   end
 
   describe '#report_counts' do


### PR DESCRIPTION
This change utilizes a new queue every submission and will avoid race conditions since queue is not thread-safe.