### PR TITLE
Rescue librato errors in timer

### DIFF
--- a/lib/pliny/librato/metrics/backend.rb
+++ b/lib/pliny/librato/metrics/backend.rb
@@ -56,7 +56,10 @@ module Pliny
           @timer = Thread.new do
             loop do
               sleep interval
-              flush_librato
+              begin
+                flush_librato
+              rescue # allow for periodic librato errors to recover
+              end
             end
           end
         end

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -167,5 +167,12 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
       sleep 0.1
       expect(librato_queue).to have_received(:submit).at_least(1).times
     end
+
+    it 'continues flushing the queue when erroring' do
+      allow(librato_queue).to receive(:submit).and_raise(RuntimeError.new)
+
+      sleep 0.2
+      expect(librato_queue).to have_received(:submit).at_least(2).times
+    end
   end
 end

--- a/spec/lib/pliny/librato/metrics/backend_spec.rb
+++ b/spec/lib/pliny/librato/metrics/backend_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe Pliny::Librato::Metrics::Backend do
 
     it 'continues flushing the queue when erroring' do
       allow(librato_queue).to receive(:submit).and_raise(RuntimeError.new)
+      expect(Pliny::ErrorReporters).to receive(:notify).at_least(1).times.and_raise(RuntimeError.new)
 
       sleep 0.2
       expect(librato_queue).to have_received(:submit).at_least(2).times


### PR DESCRIPTION
When librato connectivity has issues the timer thread crashes causing us to be paged on metrics which are required to exist.  I added a rescue in the timer thread so that the timer starts reporting metrics again once the librato connectivity comes back.